### PR TITLE
Add option to permit overlap with "always on top" windows

### DIFF
--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -18,6 +18,7 @@ const config = {
     ignoreNonnormal: readConfig("ignoreNonnormal", true),
     ignoreShell: readConfig("ignoreSpecial", true),
     ignoreTransient: readConfig("ignoreTransient", true),
+    ignoreKeepAbove: readConfig("ignoreKeepAbove", false),
     // excluded/included applications
     excludeMode: readConfig("excludeMode", true),
     excludeForeground: readConfig("excludeForeground", false),
@@ -50,7 +51,8 @@ debug("initializing");
 debug("auto restore:", config.autoRestore);
 debug("ignore non-normal:", config.ignoreNonnormal,
       "ignore shell:", config.ignoreShell,
-      "ignore transient:", config.ignoreTransient);
+      "ignore transient:", config.ignoreTransient,
+      "ignore keep above:", config.ignoreKeepAbove);
 debug("exclude (fg, bg):", config.excludeMode,
       config.excludedAppsForeground, config.excludedAppsBackground);
 debug("include (fg, bg):", config.includeMode,
@@ -353,6 +355,7 @@ function ignoreWindow(win) {
     return !(win.desktop == workspace.currentDesktop || win.onAllDesktops)
            // different desktop
         || (config.ignoreNonnormal && !win.normalWindow) // non-normal window
+        || (config.ignoreKeepAbove && win.keepAbove) // always-on-top windows
         || (config.ignoreShell // desktop shell window
             && ["plasmashell", "krunner"].includes(String(win.resourceName))
             && win.frameGeometry != workspace.clientArea(KWin.FullScreenArea, win))

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -23,6 +23,10 @@
       <label>Permit overlap with transient windows (such as dialogs and tooblars) that belong to the same main window</label>
       <default>true</default>
     </entry>
+    <entry name="ignoreKeepAbove" type="Bool">
+      <label>Permit overlap with windows in always on top mode</label>
+      <default>false</default>
+    </entry>
     <entry name="excludeMode" type="Bool">
       <label>Whether to gap all except the specified applications</label>
       <default>true</default>

--- a/contents/ui/config.ui
+++ b/contents/ui/config.ui
@@ -117,6 +117,16 @@
             </property>
            </widget>
           </item>
+          <item>
+           <widget class="QCheckBox" name="kcfg_ignoreKeepAbove">
+            <property name="text">
+             <string>windows in "always on top" mode</string>
+            </property>
+            <property name="checked">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
          </layout>
         </item>
        </layout>


### PR DESCRIPTION
In some situations user may need to have a window on top of another ­- for example, having Firefox maximized, and get Dolphin window showing on top of it for drag-n-drop. 

With Floating tiles script, you can't get such setup without unmaximizing and resizing window A first (Firefox in this case), to create some space for window B. Another option would be to add Dolphin or Firefox window to exclusion rules — but it wouldn't work if you want to make an exclusion only for such occasional situations, and preserve default behavior in all other cases. 

This PR adds a new option in settings to allow overlap with windows in "always on top" mode (e.g. "keepAbove" attribute). Option is disabled by default, and will allow user to stack any window on top of another temporarly by toggling it's "always on top" mode (either by window titlebar button or KWin's keyboard shortcut).